### PR TITLE
[feature] [main] Create `sendAuth0EmailVerification` function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@cobuildlab/8base-auth0",
-  "version": "0.0.3",
+  "name": "@cobuildlab/auth0-utils",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobuildlab/8base-auth0",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cobuildlab/8base-auth0",
+  "name": "@cobuildlab/auth0-utils",
   "version": "0.1.0",
   "description": "This is package to deal with common scenarios working with auth0 platform",
   "main": "lib/index.js",
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cobuildlab/8base-auth0.git"
+    "url": "git+https://github.com/cobuildlab/auth0-utils.git"
   },
   "keywords": [
     "8base",
@@ -25,9 +25,9 @@
   "author": "Ragomez33",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/cobuildlab/8base-auth0/issues"
+    "url": "https://github.com/cobuildlab/auth0-utils/issues"
   },
-  "homepage": "https://github.com/cobuildlab/8base-auth0#readme",
+  "homepage": "https://github.com/cobuildlab/auth0-utils#readme",
   "husky": {
     "hooks": {
       "pre-commit": "npx lint-staged",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cobuildlab/8base-auth0",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "This is package to deal with common scenarios working with auth0 platform",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export {
   createAuth0User,
   fetchUserByEmailOnAuth0,
   fetchAccessTokenOnAuth0,
+  sendAuth0EmailVerification,
 } from './utils';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,3 +126,50 @@ export const fetchAccessTokenOnAuth0 = async (
     throw new Error(error);
   }
 };
+
+/**
+ * @description Request email verification from Auth0.
+ *
+ * @param {string} auth_domain - Auth0's auth domain.
+ * @param {string} access_token Auth0's management api access token (see {@linkcode fetchAccessTokenOnAuth0})
+ * @param {string} user_id - Authenticated user ID.
+ * @param {string} client_id Auth0's machine client ID.
+ * @param {string} provider - User's authentication provider.
+ *
+ * @returns {Promise<void>} - Gracefully exit if job was successfully created.
+ *
+ * @private
+ */
+export const sendAuth0EmailVerification = async (
+  auth_domain: string,
+  access_token: string,
+  user_id: string,
+  client_id: string,
+  provider: string,
+): Promise<void> => {
+  try {
+    const response = await fetch(
+      `https://${auth_domain}/api/v2/jobs/verification-email`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${access_token}`,
+        },
+        body: JSON.stringify({
+          user_id: `${provider}|${user_id}`,
+          client_id,
+          identity: {
+            user_id,
+            provider,
+          },
+        }),
+      },
+    );
+
+    if (response.status !== 201) {
+      throw new Error(`Request failed with status code ${response.status}`);
+    }
+  } catch (e: any) {
+    throw new Error(e);
+  }
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -131,9 +131,9 @@ export const fetchAccessTokenOnAuth0 = async (
  * @description Request email verification from Auth0.
  *
  * @param {string} auth_domain - Auth0's auth domain.
- * @param {string} access_token Auth0's management api access token (see {@linkcode fetchAccessTokenOnAuth0})
+ * @param {string} access_token - Auth0's management api access token (see {@linkcode fetchAccessTokenOnAuth0}).
  * @param {string} user_id - Authenticated user ID.
- * @param {string} client_id Auth0's machine client ID.
+ * @param {string} client_id - Auth0's machine client ID.
  * @param {string} provider - User's authentication provider.
  *
  * @returns {Promise<void>} - Gracefully exit if job was successfully created.
@@ -169,7 +169,7 @@ export const sendAuth0EmailVerification = async (
     if (response.status !== 201) {
       throw new Error(`Request failed with status code ${response.status}`);
     }
-  } catch (e: any) {
+  } catch (e) {
     throw new Error(e);
   }
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,29 +147,25 @@ export const sendAuth0EmailVerification = async (
   client_id: string,
   provider: string,
 ): Promise<void> => {
-  try {
-    const response = await fetch(
-      `https://${auth_domain}/api/v2/jobs/verification-email`,
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${access_token}`,
-        },
-        body: JSON.stringify({
-          user_id: `${provider}|${user_id}`,
-          client_id,
-          identity: {
-            user_id,
-            provider,
-          },
-        }),
+  const response = await fetch(
+    `https://${auth_domain}/api/v2/jobs/verification-email`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${access_token}`,
       },
-    );
+      body: JSON.stringify({
+        user_id: `${provider}|${user_id}`,
+        client_id,
+        identity: {
+          user_id,
+          provider,
+        },
+      }),
+    },
+  );
 
-    if (response.status !== 201) {
-      throw new Error(`Request failed with status code ${response.status}`);
-    }
-  } catch (e) {
-    throw new Error(e);
+  if (response.status !== 201) {
+    throw new Error(`Request failed with status code ${response.status}`);
   }
 };


### PR DESCRIPTION
This function will allow users to quickly request email verification from Auth0 by providing the auth domain, a [management API access token](https://auth0.com/docs/security/tokens/access-tokens/management-api-access-tokens#:~:text=To%20call%20the%20Auth0%20Management,grant%20permissions%20known%20as%20scopes.), a user ID, a machine's client ID, and an auth provider. 

As a note: Auth0 references `client_id` in two different ways, a composed ID in the form of `provider|id`, and a single way, which only contains the `id` portion of the composed version. This function requires `provider` and `id` to be passed separately, which must be split beforehand when extracting the `sub` property from an Auth0 user object.